### PR TITLE
Remove dependency on req

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,19 @@ var cookie = require('cookie');
 module.exports = function (req) {
   // This is a temp hack for remembering what has been set until express has a better api for cookies
   // see https://github.com/expressjs/express/pull/2237
-  var cookiesSet = {}
+  var cookiesSet = {};
+
   return {
     set: function (name, value, options) {
       var cookieStr = cookie.serialize(name, value, options);
-      req.res.cookie.call(req.res, name, value, options);
-      cookiesSet[name] = value
+
+      // if we don't have a request object, store everything in an object
+      // and one can return all the cookies from the set
+      if (req) {
+          req.res.cookie.call(req.res, name, value, options);
+      }
+
+      cookiesSet[name] = value;
       return cookieStr;
     },
 
@@ -20,11 +27,20 @@ module.exports = function (req) {
       var opts = options || {};
       opts.expires = new Date(0);
 
-      return !!(req.res.cookie(name, '', opts));
+      try {
+          if (req) {
+              req.res.cookie(name, '', opts)
+          }
+
+          delete cookiesSet[name];
+          return true;
+      } catch (e) {
+          return false;
+      }
     },
 
     all: function () {
-      return req.cookies;
+      return cookiesSet;
     }
   }
 };

--- a/index.js
+++ b/index.js
@@ -27,11 +27,11 @@ module.exports = function (req) {
       var opts = options || {};
       opts.expires = new Date(0);
 
-      try {
-          if (req) {
-              req.res.cookie(name, '', opts)
-          }
+      if (req) {
+          req.res.cookie(name, '', opts)
+      }
 
+      try {
           delete cookiesSet[name];
           return true;
       } catch (e) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-dough",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An isomorphic JavaScript cookie library",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## Description

Rather than having all instances pass in a request object, optionally give the request object.  This means a user can pass in the request object and have everything happen automatically behind the scenes or get the cookie-dough instance and set at the end.

Also, fixes #7 
## Reviewers

@jmerrifield @heston
