### PR TITLE
Fix maxAge when running with express (express uses milliseconds)

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = function (req) {
   return {
     set: function (name, value, options) {
       var cookieStr = cookie.serialize(name, value, options);
+      if (options.maxAge) {
+        options.maxAge *= 1000; // express expects maxAge to be in milliseconds
+      }
       req.res.cookie.call(req.res, name, value, options);
       cookiesSet[name] = value
       return cookieStr;


### PR DESCRIPTION
I was running into an issue where cookies set by express were expiring much too soon. The express API expects maxAge to be specified in terms of milliseconds. This pull request simply multiplies maxAge by 1000 to get compatibility.
