### PR TITLE
Allow new versions of "cookie" module so we can use the sameSite attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ The options that you can set on a cookie:
 
 *httpOnly* - true or false
 
+*sameSite* - true, false, 'lax', 'none', 'strict'
 
 ### Removing a cookie
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-dough",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "An isomorphic JavaScript cookie library",
   "main": "index.js",
   "directories": {
@@ -11,11 +11,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/change/cookie-dough.git"
+    "url": "https://github.com/change/cookie-dough.git"
   },
   "browser": "browser.js",
   "dependencies": {
-    "cookie": "^0.1.2"
+    "cookie": ">=0.1.2 < 1"
   },
   "devDependencies": {
     "browserify": "^10.1.3",
@@ -24,10 +24,6 @@
     "mocha": "^2.2.4",
     "sinon": "^1.14.1",
     "vinyl-transform": "^1.0.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/change/cookie-dough.git"
   },
   "keywords": [
     "cookie",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-dough",
-  "version": "0.2.0",
+  "version": "0.2.0-beta.0",
   "description": "An isomorphic JavaScript cookie library",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
The [cookie](https://www.npmjs.com/package/cookie) module is now at v0.4.1 and still has the same API.  They had added `sameSite` support at v0.3.1... but we've been stuck on v0.1.x.

Adopting this change will allow us to start setting cookies with SameSite=Strict which will be a nice security improvement.