### PR TITLE
Remove duplicate key

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,6 @@
     "sinon": "^1.14.1",
     "vinyl-transform": "^1.0.0"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/change/cookie-dough.git"
-  },
   "keywords": [
     "cookie",
     "cookies",


### PR DESCRIPTION
repository key is duplicated and causing warnings in build tools such as esbuild